### PR TITLE
240619_08_이청우

### DIFF
--- a/bin/dart_debug_sample.dart
+++ b/bin/dart_debug_sample.dart
@@ -1,4 +1,3 @@
-import 'package:dart_debug_sample/dart_debug_sample.dart' as dart_debug_sample;
 import 'package:dart_debug_sample/dart_debug_sample.dart';
 
 void main() {

--- a/lib/dart_debug_sample.dart
+++ b/lib/dart_debug_sample.dart
@@ -1,70 +1,39 @@
 import 'package:intl/intl.dart';
 
 class YukymController {
+  // mm소문자는 시분초에 분을 나타낸다
+  String nowDate = DateFormat('yyyy-MM-dd').format(DateTime.now());
 
-  // DateTime.parse(_userData.value!.selectDate)
-  String nowDate = DateFormat('yyyy-mm-dd').format(DateTime.now());
-
-  late String nowTime;
-
-  // 1. 자시의 국 : 갑자1국 = getTyOne()의 값
   String getTyA() {
-    List<YukymTimeModel> timeDataOne =
-    _getTimeDataOne(nowDate);
+    List<YukymTimeModel> timeDataOne = _getTimeDataOne(nowDate);
 
     if (timeDataOne.isNotEmpty) {
-      nowTime = timeDataOne.first.ty1;
-
-      final month = nowDate.substring(5, 7);
-      if (month == '01' || month == '02') {
-        return '경오1국';
-      } else if (month == '03' || month == '04') {
-        return '경오2국';
-      } else if (month == '05' || month == '06') {
-        return '경오3국';
-      } else if (month == '07' || month == '08') {
-        return '경오4국';
-      } else if (month == '09' || month == '10') {
-        return '경오5국';
-      } else if (month == '11' || month == '12') {
-        return '경오6국';
+      final month = int.parse(nowDate.substring(5, 7));
+      if (month > 0 && month < 13) {
+        return '경오${(month + 1) ~/ 2}국';
       }
-      return nowTime;
+      return timeDataOne.first.ty1;
     } else {
-      // Handle the case when the list is empty
-      return '경오7국';  // Or any other appropriate action
+      return '경오7국';
     }
   }
 
   String getTyB() {
-    List<YukymTimeModel> timeDataOne =
-    _getTimeDataOne(nowDate);
-    String result = timeDataOne.first.ty12;
+    List<YukymTimeModel> timeDataOne = _getTimeDataOne(nowDate);
 
-    final nowTime = DateTime.now();
-    if (nowTime.hour >= 0 || nowTime.hour < 2) {
-      return timeDataOne.first.ty1;
-    } else if (nowTime.hour >= 4 || nowTime.hour < 6) {
-      return timeDataOne.first.ty2;
-    } else if (nowTime.hour >= 6 || nowTime.hour < 8) {
-      return timeDataOne.first.ty3;
-    } else if (nowTime.hour >= 8 || nowTime.hour < 10) {
-      return timeDataOne.first.ty4;
-    } else if (nowTime.hour >= 10 || nowTime.hour < 12) {
-      return timeDataOne.first.ty5;
-    } else if (nowTime.hour >= 12 || nowTime.hour < 14) {
-      return timeDataOne.first.ty6;
-    } else if (nowTime.hour >= 16 || nowTime.hour < 18) {
-      return timeDataOne.first.ty7;
-    } else if (nowTime.hour >= 18 || nowTime.hour < 20) {
-      return timeDataOne.first.ty8;
-    } else if (nowTime.hour >= 20 || nowTime.hour < 22) {
-      return timeDataOne.first.ty9;
-    } else if (nowTime.hour >= 22 || nowTime.hour < 24) {
-      return timeDataOne.first.ty10;
-    }
+    if (DateTime.now().hour < 2) return timeDataOne.first.ty1;
+    if (DateTime.now().hour < 4) return timeDataOne.first.ty2;
+    if (DateTime.now().hour < 6) return timeDataOne.first.ty3;
+    if (DateTime.now().hour < 8) return timeDataOne.first.ty4;
+    if (DateTime.now().hour < 10) return timeDataOne.first.ty5;
+    if (DateTime.now().hour < 12) return timeDataOne.first.ty6;
+    if (DateTime.now().hour < 14) return timeDataOne.first.ty7;
+    if (DateTime.now().hour < 16) return timeDataOne.first.ty8;
+    if (DateTime.now().hour < 18) return timeDataOne.first.ty9;
+    if (DateTime.now().hour < 20) return timeDataOne.first.ty10;
+    if (DateTime.now().hour < 22) return timeDataOne.first.ty11;
 
-    return result;
+    return timeDataOne.first.ty12;
   }
 
   List<YukymTimeModel> _getTimeDataOne(String nowDate) {

--- a/test/dart_debug_sample_test.dart
+++ b/test/dart_debug_sample_test.dart
@@ -2,7 +2,36 @@ import 'package:dart_debug_sample/dart_debug_sample.dart';
 import 'package:test/test.dart';
 
 void main() {
-  test('', () {
+  group('getTyA 테스트', () {
+    YukymController yukymController = YukymController();
+    test('nowDate에 월이 01, 02 이면, getTyA()는 "경오 1국" 이어야한다.', () {
+      yukymController.nowDate = '2024-01-01';
+      yukymController.getTyA();
+      expect(yukymController.getTyA(), equals('경오1국'));
 
+      yukymController.nowDate = '2024-02-01';
+      yukymController.getTyA();
+      expect(yukymController.getTyA(), equals('경오1국'));
+    });
+
+    test('nowDate에 월이 03, 04 이면, getTyA()는 "경오2국" 이어야한다.', () {
+      yukymController.nowDate = '2024-03-01';
+      yukymController.getTyA();
+      expect(yukymController.getTyA(), equals('경오2국'));
+
+      yukymController.nowDate = '2024-04-01';
+      yukymController.getTyA();
+      expect(yukymController.getTyA(), equals('경오2국'));
+    });
+
+    test('nowDate에 월이 01, 12 사이의 숫자가 아니면, getTyA()는 "갑자1국" 이어야한다.', () {
+      yukymController.nowDate = '2024-14-01';
+      yukymController.getTyA();
+      expect(yukymController.getTyA(), equals('갑자1국'));
+
+      yukymController.nowDate = '2024-00-01';
+      yukymController.getTyA();
+      expect(yukymController.getTyA(), equals('갑자1국'));
+    });
   });
 }


### PR DESCRIPTION
- DateFormat('yyyy-mm-dd') mm 소문자는 시분초에 분을 나타낸다. 대문자로 변경
- getTyA에서  month를 int 타입으로 변환 후  나누기한 몫으로  return 값에 적용 함 
   `경오${(month + 1) ~/ 2}국'`   + 1은   홀수 월 때문에 필요함   
- getTyB는 `nowTime.hour >= 0 || nowTime.hour < 2` 조건수정
- test code에서 getTyB는 DateTime.now().hour  부분 때문에 작성 못함